### PR TITLE
Better accept header parsing

### DIFF
--- a/accept.go
+++ b/accept.go
@@ -1,0 +1,19 @@
+package main
+
+import "strings"
+import "regexp"
+
+// False positive for application/ld+ld, application/activity+ld, application/json+json
+var activityRegexp = regexp.MustCompile("application\\/(ld|json|activity)((\\+(ld|json))|$)")
+
+func acceptActivity(header string) bool {
+	accept := false
+	if strings.Contains(header, ";") {
+		split := strings.Split(header, ";")
+		accept = accept || activityRegexp.MatchString(split[0])
+		accept =  accept || strings.Contains(split[len(split)-1], "profile=\"https://www.w3.org/ns/activitystreams\"")
+	} else {
+		accept = accept || activityRegexp.MatchString(header)
+	}
+	return accept
+}

--- a/main.go
+++ b/main.go
@@ -33,7 +33,6 @@ var SiteEmailPassword = GetConfigValue("emailpass")
 var SiteEmailServer = GetConfigValue("emailserver")   //mail.fchan.xyz
 var SiteEmailPort = GetConfigValue("emailport")       //587
 
-var ldjson = "application/ld+json"		
 var activitystreams = "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\""
 
 func main() {
@@ -137,7 +136,7 @@ func main() {
 		}
 
 		if mainActor {
-			if accept == activitystreams || accept == ldjson {
+			if acceptActivity(accept) {
 				GetActorInfo(w, db, Domain)
 				return
 			}
@@ -180,7 +179,7 @@ func main() {
 		}
 
 		if actorMain || actorMainPage {
-			if accept == activitystreams || accept == ldjson {
+			if acceptActivity(accept) {
 				GetActorInfo(w, db, actor.Id)
 				return 
 			}
@@ -267,7 +266,7 @@ func main() {
 
 		//catch all
 		if actorPost {
-			if accept == activitystreams || accept == ldjson {			
+			if acceptActivity(accept) {			
 				GetActorPost(w, db, path)
 				return 
 			}


### PR DESCRIPTION
As discussed in #11 this PR parses accept headers for activitystreams and json more carefully.
It has some false positives (application/ld+ld, application/activity+ld, application/json+json) but I think if a client is sending such strange headers that's their problem.