### PR TITLE
Changed "top.html" width of board title

### DIFF
--- a/static/top.html
+++ b/static/top.html
@@ -1,5 +1,5 @@
 {{ define "top" }}
-<div style="margin: 0 auto; width: 400px; margin-bottom: 100px;">
+<div style="margin: 0 auto; width: 700px; margin-bottom: 100px;">
   <h1 style="text-align: center; color: #af0a0f;">/{{ .Board.Name }}/ - {{ .Board.PrefName }}</h1>
   <p style="text-align: center;">{{ .Board.Summary }}</p>
   {{ $len := len .Posts }}


### PR DESCRIPTION
When the width of that div is only 400px, surprise! Your board title can only be one or two words before it breaks. 
I do think having line breaks is sensible, so I widened it.