### PR TITLE
Add the port number to the `Domain`

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ import (
 var Port = ":" + GetConfigValue("instanceport")
 var TP   = GetConfigValue("instancetp")
 var Instance = GetConfigValue("instance")
-var Domain = TP + "" + Instance
+var Domain = TP + "" + Instance + Port
 
 var authReq = []string{"captcha","email","passphrase"}
 


### PR DESCRIPTION
This is to fix some issues such as authorization failing to log us in as an admin when hosting on a different port number.