### PR TITLE
Improve spam protection

### DIFF
--- a/database.go
+++ b/database.go
@@ -1327,7 +1327,7 @@ func GetRandomCaptcha(db *sql.DB) string{
 
 	rows, err := db.Query(query)
 
-	CheckError(err, "could not get captcha")
+	CheckError(err, "could not get a random captcha")
 
 	var verify string
 
@@ -1336,7 +1336,7 @@ func GetRandomCaptcha(db *sql.DB) string{
 	rows.Next()
 	err = rows.Scan(&verify)
 	
-	CheckError(err, "Could not get verify captcha")
+	CheckError(err, "could not get a random captcha")
 
 	return verify
 }
@@ -1346,14 +1346,14 @@ func GetCaptchaTotal(db *sql.DB) int{
 
 	rows, err := db.Query(query)
 	
-	CheckError(err, "could not get query captcha total")	
+	CheckError(err, "could not query the total amount of captchas")	
 
 	defer rows.Close()
 	
 	var count int
 	for rows.Next(){
 		if err := rows.Scan(&count); err != nil{
-			CheckError(err, "could not get captcha total")
+			CheckError(err, "could not get the total amount of captchas")
 		}
 	}
 
@@ -1366,7 +1366,7 @@ func GetCaptchaCodeDB(db *sql.DB, verify string) string {
 
 	rows, err := db.Query(query, verify)
 
-	CheckError(err, "could not get captcha verifciation")
+	CheckError(err, "could not get a captcha from the db")
 
 	defer rows.Close()
 
@@ -1376,7 +1376,7 @@ func GetCaptchaCodeDB(db *sql.DB, verify string) string {
 	err = rows.Scan(&code)
 
 	if err != nil {
-		fmt.Println("Could not get verification captcha")
+		fmt.Println("could not get a captcha from the db")
 	}
 
 	return code
@@ -1397,7 +1397,7 @@ func GetActorAuth(db *sql.DB, actor string) []string {
 		var e string
 		err = rows.Scan(&e)
 
-		CheckError(err, "could not get actor auth row scan")		
+		CheckError(err, "could not get the actor auth from scanned row")		
 
 		auth = append(auth, e)
 	}
@@ -1410,9 +1410,30 @@ func DeleteCaptchaCodeDB(db *sql.DB, verify string) {
 
 	_, err := db.Exec(query, verify)	
 
-	CheckError(err, "could not delete captcah code db")
+	CheckError(err, "could not delete captcha code from the db")
 
 	os.Remove("./" + verify)
+}
+
+func DeleteAllCaptchas(db *sql.DB) {
+	query := `select identifier from verification where type='captcha'`
+	rows, err := db.Query(query)	
+	CheckError(err, `could not delete the captchas from the "public" directory`)
+
+	defer rows.Close()
+
+	for rows.Next() {
+		var id string
+		err = rows.Scan(&id)
+		CheckError(err, `could not delete all captchas from the "public" directory`)
+		os.Remove("./" + id)
+	}
+
+	query = `delete from verification where type='captcha'`
+
+	_, err = db.Exec(query)
+
+	CheckError(err, "could not delete all captchas from the db")
 }
 
 func EscapeString(text string) string {

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,5 @@ require (
 	github.com/lib/pq v1.9.0
 	github.com/simia-tech/crypt v0.5.0
 	golang.org/x/text v0.3.6
+	github.com/mojocn/base64Captcha v1.3.4
 )

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,14 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPhW6m+TnJw=
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
+github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF08vX0COfcOBJRhZ8lUbR+ZWIs0Y5g=
+github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/gomodule/redigo v2.0.0+incompatible h1:K/R+8tc58AaqLkqG2Ol3Qk+DR/TlNuhuh457pBFPtt0=
 github.com/gomodule/redigo v2.0.0+incompatible/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
 github.com/lib/pq v1.9.0 h1:L8nSXQQzAYByakOFMTwpjRoHsMJklur4Gi59b6VivR8=
 github.com/lib/pq v1.9.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/mojocn/base64Captcha v1.3.4 h1:9+MZzjNSfBHniYOIpoP4xyDDPCXy14JIjsEFf89PlNw=
+github.com/mojocn/base64Captcha v1.3.4/go.mod h1:wAQCKEc5bDujxKRmbT6/vTnTt5CjStQ8bRfPWUuz/iY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/simia-tech/crypt v0.5.0 h1:Y8xfAGqgd2wW2o4E63WIy9xr9w4jC1tDsOBHGKiqP0s=
@@ -14,8 +18,11 @@ github.com/stretchr/testify v1.2.0 h1:LThGCOvhuJic9Gyd1VBCkhyUXmO8vKaBFvBsJ2k03r
 github.com/stretchr/testify v1.2.0/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 golang.org/x/crypto v0.0.0-20181112202954-3d3f9f413869 h1:kkXA53yGe04D0adEYJwEVQjeBppL01Exg+fnMjfUraU=
 golang.org/x/crypto v0.0.0-20181112202954-3d3f9f413869/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/image v0.0.0-20190501045829-6d32002ffd75 h1:TbGuee8sSq15Iguxu4deQ7+Bqq/d2rsQejGcEtADAMQ=
+golang.org/x/image v0.0.0-20190501045829-6d32002ffd75/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/sys v0.0.0-20181116161606-93218def8b18 h1:Wh+XCfg3kNpjhdq2LXrsiOProjtQZKme5XUx7VcxwAw=
 golang.org/x/sys v0.0.0-20181116161606-93218def8b18/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/main.go
+++ b/main.go
@@ -57,6 +57,9 @@ func main() {
 
 	RunDatabaseSchema(db)
 
+	//Make sure that we have a clean palette and we don't get any 404's if the admin deleted some captcha images in the `public` directory
+	DeleteAllCaptchas(db)
+	
 	go MakeCaptchas(db, 100)
 
 	*Key = CreateKey(32)

--- a/verification.go
+++ b/verification.go
@@ -9,6 +9,7 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"image/color"
 	"net/smtp"

--- a/verification.go
+++ b/verification.go
@@ -1,24 +1,30 @@
 package main
 
-import "fmt"
-import "database/sql"
-import _ "github.com/lib/pq"
-import	"net/smtp"
-import "time"
-import "os/exec"
-import "os"
-import "math/rand"
-import "crypto"
-import "crypto/rsa"
-import "crypto/x509"
-import "crypto/sha256"
-import "encoding/pem"
-import "encoding/base64"
-import crand "crypto/rand"
-import "io/ioutil"
-import "strings"
-import "net/http"
-import "regexp"
+import (
+	"bufio"
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"database/sql"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"image/color"
+	"net/smtp"
+	"os"
+	"time"
+
+	_ "github.com/lib/pq"
+
+	crand "crypto/rand"
+	"io/ioutil"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/mojocn/base64Captcha")
+
 
 type Verify struct {
 	Type string
@@ -383,52 +389,23 @@ func CreateNewCaptcha(db *sql.DB){
 			break
 		}
 	}
-	
-	captcha := Captcha()
+	textDriver := base64Captcha.NewDriverString(98, 200, 35, base64Captcha.OptionShowHollowLine | base64Captcha.OptionShowSineLine | base64Captcha.OptionShowSlimeLine, 4, "ABEFHKMNPQRSUVWXYZ#$&", &color.RGBA{}, []string{"Flim-Flam.ttf", "RitaSmith.ttf", "wqy-microhei.ttc"})
+	c := base64Captcha.NewCaptcha(textDriver, base64Captcha.DefaultMemStore)
 
-	var pattern string
-	rnd := fmt.Sprintf("%d", rand.Intn(3))
-
-	srnd := string(rnd)
-
-	switch srnd {
-	case "0" :
-		pattern = "pattern:verticalbricks"
-		break
-
-	case "1" :
-		pattern = "pattern:verticalsaw"
-		break
-		
-	case "2" :
-		pattern = "pattern:hs_cross"
-		break		
-
-	}
-	
-	cmd := exec.Command("convert", "-size", "200x98", pattern, "-transparent", "white", file)
-
-	err := cmd.Run()
-
-	CheckError(err, "error with captcha first pass")
-	
-	cmd  = exec.Command("convert", file, "-fill", "blue", "-pointsize", "62", "-annotate", "+0+70", captcha, "-tile", "pattern:left30", "-gravity", "center", "-transparent", "white", file)
-
-	err = cmd.Run()
-
-	CheckError(err, "error with captcha second pass")
-
-	rnd = fmt.Sprintf("%d", rand.Intn(24) - 12)
-	
-	cmd  = exec.Command("convert", file, "-rotate", rnd, "-wave", "5x35", "-distort", "Arc", "20", "-wave", "2x35", "-transparent", "white", file)
-
-	err = cmd.Run()
-
-	CheckError(err, "error with captcha third pass")	
+	_, content, answer := Captcha(c)
+	image, err := c.Driver.DrawCaptcha(content)
+	CheckError(err, "failed to draw captcha")
+	fileId, err := os.Create(file)
+	CheckError(err, "failed to create captcha image")
+	writer := bufio.NewWriter(fileId)
+	_, err = image.WriteTo(writer)
+	CheckError(err, "failed to write captcha image")
+	err = writer.Flush()
+	CheckError(err, "failed to write captcha image")
 
 	var verification Verify
 	verification.Type         = "captcha"	
-	verification.Code         = captcha
+	verification.Code         = answer
 	verification.Identifier = file
 
 	CreateVerification(db, verification)
@@ -477,16 +454,8 @@ func BoardHasAuthType(db *sql.DB, board string, auth string) bool {
 	return false
 }
 
-func Captcha() string {
-	rand.Seed(time.Now().UTC().UnixNano())
-	domain := "ABEFHKMNPQRSUVWXYZ#$&"
-	rng := 4
-	newID := ""
-	for i := 0; i < rng; i++ {
-		newID += string(domain[rand.Intn(len(domain))])
-	}
-	
-	return newID
+func Captcha(driver *base64Captcha.Captcha) (string, string, string) {
+	return driver.Driver.GenerateIdQuestionAnswer()
 }	
 
 func CreatePem(db *sql.DB, actor Actor) {

--- a/verification.go
+++ b/verification.go
@@ -389,7 +389,7 @@ func CreateNewCaptcha(db *sql.DB){
 			break
 		}
 	}
-	textDriver := base64Captcha.NewDriverString(98, 200, 35, base64Captcha.OptionShowHollowLine | base64Captcha.OptionShowSineLine | base64Captcha.OptionShowSlimeLine, 4, "ABEFHKMNPQRSUVWXYZ#$&", &color.RGBA{}, []string{"Flim-Flam.ttf", "RitaSmith.ttf", "wqy-microhei.ttc"})
+	textDriver := base64Captcha.NewDriverString(98, 200, 35, base64Captcha.OptionShowHollowLine | base64Captcha.OptionShowSineLine | base64Captcha.OptionShowSlimeLine, 4, "ABEFHKMNPQRSUVWXYZ#$&", &color.RGBA{}, []string{"chromohv.ttf", "DeborahFancyDress.ttf", "RitaSmith.ttf", "wqy-microhei.ttc"})
 	c := base64Captcha.NewCaptcha(textDriver, base64Captcha.DefaultMemStore)
 
 	_, content, answer := Captcha(c)


### PR DESCRIPTION
A.K.A. use a readily available library to improve CAPTCHA quality
It also clears all previously generated captchas on startup in case the administrator has deleted some in the `public` directory.
ImageMagick can remain as a requirement for the future for thumbnailing.
I can also add the option to configure the parameters for CAPTCHA generation, but I don't think this is needed.

![Example 1](https://user-images.githubusercontent.com/86490230/124294181-b3cb1280-db57-11eb-9540-ec68256c4dfb.png)
![Example 2](https://user-images.githubusercontent.com/86490230/124294242-c1809800-db57-11eb-855b-ac87ade56b12.png)

