### PR TITLE
Trim strings before firing getactor requests

### DIFF
--- a/main.go
+++ b/main.go
@@ -1875,7 +1875,7 @@ func GetActor(id string) Actor {
 	if ActorCache[actor+"@"+instance].Id != "" {
 		respActor = ActorCache[actor+"@"+instance]
 	} else {
-		req, err := http.NewRequest("GET", id, nil)
+		req, err := http.NewRequest("GET", strings.TrimSpace(id), nil)
 
 		CheckError(err, "error with getting actor req")
 


### PR DESCRIPTION
The ideal solution to this problem would have been to properly sanitize input so that admins couldn't accidentally put trailing/leading spaces in URLs to follow, but this is in production now and FChannel doesn't have any system for database migration/versioning.
So instead we can just sanitize it in the http.NewRequest to avoid a panic. Other instances of http.NewRequest that use user input could probably benefit from this too but I didn't want to go off the rails and break anything without a test suite.

Fix for issue #58 